### PR TITLE
🐱 beat-1: pr-label → reusable caller (@v1)

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,3 +1,9 @@
+# Thin caller -> reusable pr-label in bendoerr-terraform-modules/workflows.
+# pr-label is the moving-@v1 lane (can't block a merge). Trigger stays local (can't live in a reusable
+# workflow). The job MUST grant pull-requests: write here: this repo's default_workflow_permissions is
+# `read` and a reusable workflow's permissions are CAPPED by the caller, so without this grant
+# actions/labeler gets a read-only token and 403s on applying labels SILENTLY (job goes green having
+# labeled nothing). labeler still reads this repo's own .github/labeler.yml (caller context).
 name: Label Pull Request
 
 on:
@@ -8,15 +14,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: read
       pull-requests: write
-
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 #v6.1.0
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1


### PR DESCRIPTION
**Beat 1 of the reusable-workflow consolidation** (proposal: `code-kitten/ops/reusable-workflows-proposal.md`). First repo to consume the new `bendoerr-terraform-modules/workflows` reusables.

## what
Replaces this repo's per-repo `pr-label.yml` body with a thin caller pinning `@v1`:
```yaml
jobs:
  label:
    permissions:
      contents: read
      pull-requests: write
    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1
```

## why pr-label as the canary
Lowest stakes: byte-identical across 8 repos already, zero inputs, **not a merge gate** — so this beat proves the `workflow_call` plumbing end-to-end with nothing at risk.

## what to watch (this is the test)
1. the `label / label` check appears + runs green (rename from `label` is cosmetic — no `required_status_checks` in the ruleset, verified)
2. labeler **actually applies labels** — not a silent 403. The caller grants `pull-requests: write` because this repo's `default_workflow_permissions` is `read` and a reusable workflow's perms are capped by the caller (OMBB's catch — without it the job goes green having labeled nothing).
3. labeler reads **this repo's** `.github/labeler.yml` (caller context), so existing label rules are preserved.

If this goes green + labels land, beat 2 (CodeQL/`code_scanning` rehearsal) is next, then fan-out. @oldmanbendobot for the second eye.