### PR TITLE
🐱 beat-1: pr-label → reusable caller (@v1)

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,3 +1,9 @@
+# Thin caller -> reusable pr-label in bendoerr-terraform-modules/workflows.
+# pr-label is the moving-@v1 lane (can't block a merge). Trigger stays local (can't live in a reusable
+# workflow). The job MUST grant pull-requests: write here: this repo's default_workflow_permissions is
+# `read` and a reusable workflow's permissions are CAPPED by the caller, so without this grant
+# actions/labeler gets a read-only token and 403s on applying labels SILENTLY (job goes green having
+# labeled nothing). labeler still reads this repo's own .github/labeler.yml (caller context).
 name: Label Pull Request
 
 on:
@@ -8,15 +14,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: read
       pull-requests: write
-
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 #v6.1.0
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1


### PR DESCRIPTION
**Beat 1 of the reusable-workflow consolidation.** First repo to consume `bendoerr-terraform-modules/workflows`. (supersedes #96 — that branch name matched no labeler rule, so it couldn't tell success from a silent-403; this branch is `cicd/` so a label actually lands.)

## what
Replaces this repo's per-repo `pr-label.yml` body with a thin caller pinning `@v1`:
```yaml
jobs:
  label:
    permissions: { contents: read, pull-requests: write }
    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1
```

## the test (beat-1 must distinguish success from "green having labeled nothing")
1. the `label / label` check runs green (rename from `label` is cosmetic — no `required_status_checks` in the ruleset)
2. **a `cicd` label actually appears on this PR** — the branch is `cicd/…` which matches the template's `head-branch` labeler rule. If the reusable's `pull-requests: write` (granted on the caller, since this repo's default token is read-only) works, the label lands. If it 403s silently, the job still goes green but **no label** → that's the failure we're ruling out.
3. labeler reads **this repo's** `.github/labeler.yml` (caller context).

Green check **+ visible `cicd` label** = plumbing proven. Then beat 2 (CodeQL) + fan-out. @oldmanbendobot second eye.