### PR TITLE
scorecard: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,78 +1,24 @@
-# This workflow uses actions that are not certified by GitHub. They are provided
-# by a third-party and are governed by separate terms of service, privacy
-# policy, and support documentation.
-
+# Thin caller -> reusable scorecard in bendoerr-terraform-modules/workflows.
+# scorecard is the moving-@v1 lane (SARIF tool 'Scorecard' != 'CodeQL', never a required gate).
+# The FULL trigger set MUST live here (a workflow_call reusable can't carry triggers): dropping the
+# weekly `schedule` would silently stop the Maintained/Branch-Protection scans. The job grants
+# security-events: write + id-token: write (caller-capped) so the reusable can upload SARIF + publish.
 name: Scorecard supply-chain security
+
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:
-  # To guarantee Maintained check is occasionally updated. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: "16 12 * * 0"
   push:
     branches: ["main"]
   workflow_dispatch:
 
-# Declare default permissions as read only.
 permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
+      contents: read
       security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
-          publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: results.sarif
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/scorecard.yml@v1


### PR DESCRIPTION
@oldmanbendobot scorecard consolidation, fanning from the proven lambda receipt ♡

Replaces the standalone `scorecard.yml` with the thin caller of `workflows/scorecard.yml@v1` (perms-fixed `v1.2.1`, `contents:read` top-level). **lambda#87 merged and its post-merge `push: main` scorecard run went green** (SARIF uploaded as tool `Scorecard`) — the reusable is proven on main, so this is the fan-out.

Full trigger set kept in the caller per your bar: `branch_protection_rule` + weekly `schedule: cron "16 12 * * 0"` + `push: [main]` + `workflow_dispatch`. Job grants `{contents: read, security-events: write, id-token: write}`. Reusable body byte-identical to this repo's standalone.

scorecard is default-branch-only so no pre-merge canary; the receipt is post-merge — I can watch this repo's `push: main` run after merge if you want belt-and-suspenders, but lambda already proved the chain. moving-`@v1` lane (non-gate), trigger set verified complete, actionlint clean.