### PR TITLE
infracost: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -1,3 +1,6 @@
+# Thin caller -> reusable infracost in bendoerr-terraform-modules/workflows (moving-@v1 lane).
+# PR trigger lives here (reusables are workflow_call-only). the secret is passed explicitly (least-privilege — only INFRACOST_API_KEY, not the whole secret context).
+# Job MUST grant contents:read + pull-requests:write (caller-capped) so the cost comment can post.
 name: Infracost
 
 on:
@@ -10,48 +13,9 @@ permissions:
 
 jobs:
   report:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: read
       pull-requests: write
-
-    steps:
-      - uses: infracost/actions/setup@d51fc54d23c9ad90f984b884257bd96dc2625067 # v4.1.0
-        with:
-          api-key: ${{ secrets.INFRACOST_API_KEY }}
-
-      # Checkout the base branch of the pull request (e.g. main/master).
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-
-      - run: |
-          infracost breakdown --config-file=infracost.yml \
-                              --format=json \
-                              --out-file=/tmp/infracost-base.json
-
-      # Checkout the current PR branch so we can create a diff.
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      # Generate an Infracost diff and save it to a JSON file.
-      - run: |
-          infracost diff  --config-file=infracost.yml \
-                          --format=json \
-                          --compare-to=/tmp/infracost-base.json \
-                          --out-file=/tmp/infracost.json
-
-      # Posts a comment to the PR using the 'update' behavior.
-      # This creates a single comment and updates it. The "quietest" option.
-      # The other valid behaviors are:
-      #   delete-and-new - Delete previous comments and create a new one.
-      #   hide-and-new - Minimize previous comments and create a new one.
-      #   new - Create a new cost estimate comment on every push.
-      # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
-      - run: |
-          infracost comment github --path=/tmp/infracost.json \
-                                   --repo="${GITHUB_REPOSITORY}" \
-                                   --github-token=${{github.token}} \
-                                   --pull-request=${{github.event.pull_request.number}} \
-                                   --behavior=update \
-                                   --show-skipped
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/infracost.yml@v1
+    secrets:
+      INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}


### PR DESCRIPTION
@oldmanbendobot infracost consolidation, fanning from the merged reusable ♡

Thin caller of `workflows/infracost.yml@v1` (v1.2.4). **`INFRACOST_API_KEY` passed explicitly** (least-privilege, per your call — not `secrets: inherit`). Own `infracost.yml` config preserved. Job grants `contents:read` + `pull-requests:write` for the cost comment.

**On-PR canary:** infracost triggers on `pull_request`, so this PR runs its own infracost cost-comment — the real receipt, right here. (template also gains the harden-runner step it was missing.) moving-`@v1` lane.